### PR TITLE
CRUD category & category_tree_path

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,8 @@ gem 'activeadmin'
 gem 'devise'
 # 
 gem 'rails-i18n'
+# 階層構造(閉包テーブル)
+gem 'closure_tree'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,8 @@ gem 'devise'
 gem 'rails-i18n'
 # 階層構造(閉包テーブル)
 gem 'closure_tree'
+# active_adminでclosuretableなどを使いやすくする
+gem "active_admin-sortable_tree", "~> 2.0.0"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,9 @@ GEM
     chromedriver-helper (1.2.0)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
+    closure_tree (6.6.0)
+      activerecord (>= 4.1.0)
+      with_advisory_lock (>= 3.0.0)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -271,6 +274,8 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    with_advisory_lock (4.0.0)
+      activerecord (>= 4.2)
     xpath (3.1.0)
       nokogiri (~> 1.8)
 
@@ -283,6 +288,7 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   chromedriver-helper
+  closure_tree
   coffee-rails (~> 4.2)
   devise
   factory_bot_rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_admin-sortable_tree (2.0.0)
+      activeadmin (>= 1.1)
+      coffee-rails
+      jquery-rails
+      sass (~> 3.1)
     activeadmin (1.3.1)
       arbre (>= 1.1.1)
       coffee-rails
@@ -283,6 +288,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_admin-sortable_tree (~> 2.0.0)
   activeadmin
   bootsnap (>= 1.1.0)
   byebug

--- a/app/admin/articles.rb
+++ b/app/admin/articles.rb
@@ -1,16 +1,27 @@
 ActiveAdmin.register Article do
 # See permitted parameters documentation:
 # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
-#
-# permit_params :list, :of, :attributes, :on, :model
-permit_params :title, :sentence
-#
-# or
-#
+  permit_params :title, :sentence, :category_id
 # permit_params do
 #   permitted = [:permitted, :attributes]
 #   permitted << :other if params[:action] == 'create' && current_user.admin?
 #   permitted
 # end
+
+  form do |f|
+    f.inputs do
+      f.input :title
+      f.input :category_id,
+        as: :select,
+        collection: Category.tree_type_order.map { |c| [c.name, c.id] }
+        #collection: Category.tree_type_order.map { |c| ['-' * c.depth + c.name, c.id] }
+      f.input :sentence
+    end
+    f.semantic_errors
+    f.actions
+  end
+
+  controller do
+  end
 
 end

--- a/app/admin/categories.rb
+++ b/app/admin/categories.rb
@@ -1,0 +1,17 @@
+ActiveAdmin.register Category do
+# See permitted parameters documentation:
+# https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
+config.filters = false # the default filters don't work unfortunately
+permit_params :name, :parent_id #, category_hierarchies: [:ancestor_id, :descendant_id, :generations]
+
+sortable tree: true,
+  sorting_attribute: :id,
+  parent_method: :parent,
+  children_method: :children,
+  roots_method: :roots
+
+index :as => :sortable do
+  label :name # item content
+  actions
+  end
+end

--- a/app/assets/javascripts/active_admin.js.coffee
+++ b/app/assets/javascripts/active_admin.js.coffee
@@ -1,1 +1,2 @@
 #= require active_admin/base
+#= require active_admin/sortable

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -10,7 +10,8 @@
 // Active Admin's got SASS!
 @import "active_admin/mixins";
 @import "active_admin/base";
-
+// For active_admin-sortable_tree
+@import "active_admin/sortable";
 // Overriding any non-variable SASS must be done after the fact.
 // For example, to change the default status-tag color:
 //

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,2 +1,3 @@
 class Article < ApplicationRecord
+  #belongs_to :category
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,3 +1,5 @@
 class Article < ApplicationRecord
-  #belongs_to :category
+  belongs_to :category
+  validates :title, presence: true, uniqueness: true
+  validates :sentence, presence: true
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -2,4 +2,23 @@ class Category < ApplicationRecord
   has_closure_tree ##閉包テーブルclosure_tree用
   has_many :articles
   validates :name, presence: true, uniqueness: true
+
+  ##tree表示用
+  def self.tree_type_order
+    ##postgres用
+    query = <<-SQL
+  SELECT c.id,CONCAT(depth,c.name) AS name
+  FROM (
+  SELECT h.descendant_id,
+  STRING_AGG('','-') AS depth,
+  STRING_AGG(LPAD(CAST(h.ancestor_id AS text), 2, '0'), '-' ORDER BY h.generations DESC) AS path
+  FROM category_hierarchies AS h
+  GROUP BY h.descendant_id
+  ) AS t
+  INNER JOIN categories AS c
+  ON c.id = t.descendant_id
+  ORDER BY path asc
+    SQL
+    self.find_by_sql(query)
+  end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,4 +1,5 @@
 class Category < ApplicationRecord
   has_closure_tree ##閉包テーブルclosure_tree用
+  #has_many :articles
   validates :name, presence: true
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,5 +1,5 @@
 class Category < ApplicationRecord
   has_closure_tree ##閉包テーブルclosure_tree用
-  #has_many :articles
-  validates :name, presence: true
+  has_many :articles
+  validates :name, presence: true, uniqueness: true
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,4 @@
+class Category < ApplicationRecord
+  has_closure_tree ##閉包テーブルclosure_tree用
+  validates :name, presence: true
+end

--- a/db/migrate/20180829053414_create_categories.rb
+++ b/db/migrate/20180829053414_create_categories.rb
@@ -1,0 +1,9 @@
+class CreateCategories < ActiveRecord::Migration[5.2]
+  def change
+    create_table :categories do |t|
+      t.string :name, comment: "カテゴリ名", null: false, unique: true
+      t.integer :parent_id, index: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180829055606_create_category_hierarchies.rb
+++ b/db/migrate/20180829055606_create_category_hierarchies.rb
@@ -1,0 +1,16 @@
+class CreateCategoryHierarchies < ActiveRecord::Migration[5.2]
+  def change
+    create_table :category_hierarchies, id: false do |t|
+      t.integer :ancestor_id, null: false
+      t.integer :descendant_id, null: false
+      t.integer :generations, null: false
+    end
+
+    add_index :category_hierarchies, [:ancestor_id, :descendant_id, :generations],
+      unique: true,
+      name: "category_anc_desc_idx"
+
+    add_index :category_hierarchies, [:descendant_id],
+      name: "category_desc_idx"
+  end
+end

--- a/db/migrate/20180903054246_add_category_id_to_article.rb
+++ b/db/migrate/20180903054246_add_category_id_to_article.rb
@@ -1,0 +1,5 @@
+class AddCategoryIdToArticle < ActiveRecord::Migration[5.2]
+  def change
+    add_column :articles, :category_id, :integer, comment: 'カテゴリID'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_28_074015) do
+ActiveRecord::Schema.define(version: 2018_08_29_055606) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,6 +46,22 @@ ActiveRecord::Schema.define(version: 2018_08_28_074015) do
     t.text "sentence", null: false, comment: "文章"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "categories", force: :cascade do |t|
+    t.string "name", null: false, comment: "カテゴリ名"
+    t.integer "parent_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["parent_id"], name: "index_categories_on_parent_id"
+  end
+
+  create_table "category_hierarchies", id: false, force: :cascade do |t|
+    t.integer "ancestor_id", null: false
+    t.integer "descendant_id", null: false
+    t.integer "generations", null: false
+    t.index ["ancestor_id", "descendant_id", "generations"], name: "category_anc_desc_idx", unique: true
+    t.index ["descendant_id"], name: "category_desc_idx"
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_29_055606) do
+ActiveRecord::Schema.define(version: 2018_09_03_054246) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 2018_08_29_055606) do
     t.text "sentence", null: false, comment: "文章"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "category_id", comment: "カテゴリID"
   end
 
   create_table "categories", force: :cascade do |t|

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :category do
+    name "MyString"
+  end
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Category, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
カテゴリのCRUDを可能にする。

- [x] categoryモデルの作成

- [x] Closure_treeGEMの導入
今回は閉包テーブルの作成にClosure_treeGEMを使う。
・assets/stylesheetsとasset/javascriptにソースを追加

- [x] category_hierarchyモデルの作成
bundle exec rails g closure_tree:migration category

- [x] active_admin-sortable_treeGEMを導入
active_adminでツリー表記をできるようにするために導入

- [x] Active_adminでcategoryがCRUDできる

- [x] Articleでカテゴリがセレクトボックスで選べる
階層がわかるように設定済